### PR TITLE
Add logging documentation and example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ src/
   ui/            # UI helpers
   main.py        # Entry point
 ```
+
+## Logging
+
+The rule engine in `dsl.rules` relies on Python's standard `logging` module.
+If evaluating a rule condition raises an exception, the error is caught and a
+warning is emitted with the failing condition text. The logger is obtained with
+`logging.getLogger(__name__)` so it inherits the configuration of your
+application.
+
+You can enable basic logging output at program start-up, for example in
+`src/main.py`:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(levelname)s:%(name)s:%(message)s")
+```

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 from cell.simulation import Simulation
+import logging
+
+# Example logging configuration. The rule engine in ``dsl.rules`` uses a logger
+# named after its module, so configuring logging here controls its output.
+logging.basicConfig(level=logging.INFO,
+                    format="%(levelname)s:%(name)s:%(message)s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand README with description of logging in `dsl.rules`
- show basic logging configuration in `src/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7220d56c832c8a1a0fe202e53faa