### PR TITLE
Add basic DSL rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,19 @@ import logging
 logging.basicConfig(level=logging.INFO,
                     format="%(levelname)s:%(name)s:%(message)s")
 ```
+
+## Example DSL Rule
+
+The DSL allows you to register simple condition-action pairs evaluated on a
+dictionary-like state. The helper ``add_basic_rules`` defines an example rule
+that increases ``health`` when it drops below ``50``:
+
+```python
+from dsl import RuleEngine, add_basic_rules
+
+engine = RuleEngine()
+add_basic_rules(engine)
+engine.update_state(health=40)
+engine.evaluate()
+print(engine.state["health"])  # 41.0
+```

--- a/src/cell/organelles.py
+++ b/src/cell/organelles.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pygame
 import random
-from src.logger_config import logger
+from logger_config import logger
 
 
 class Organelle:

--- a/src/cell/simulation.py
+++ b/src/cell/simulation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pygame
-from src.logger_config import logger
+from logger_config import logger
 
 from .organelles import (
     Cell,

--- a/src/dsl/__init__.py
+++ b/src/dsl/__init__.py
@@ -1,0 +1,6 @@
+"""DSL utilities."""
+
+from .rules import RuleEngine
+from .simple_rules import add_basic_rules
+
+__all__ = ["RuleEngine", "add_basic_rules"]

--- a/src/dsl/simple_rules.py
+++ b/src/dsl/simple_rules.py
@@ -1,0 +1,16 @@
+"""Collection of simple example rules for the RuleEngine."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .rules import RuleEngine
+
+
+def add_basic_rules(engine: RuleEngine) -> None:
+    """Register a basic example rule on the given engine."""
+
+    def restore_health(state: Dict[str, float]) -> None:
+        state["health"] = state.get("health", 0.0) + 1.0
+
+    engine.add_rule("health < 50", restore_health)

--- a/src/tests/test_rules.py
+++ b/src/tests/test_rules.py
@@ -24,3 +24,14 @@ def test_rule_condition_exception_logs_warning(caplog):
     assert record.levelname == "WARNING"
     assert "1 / 0" in record.getMessage()
     assert "division by zero" in record.getMessage()
+
+
+def test_basic_rule_increases_health():
+    engine = RuleEngine()
+    from dsl.simple_rules import add_basic_rules
+
+    engine.update_state(health=40)
+    add_basic_rules(engine)
+    engine.evaluate()
+
+    assert engine.state["health"] == 41.0


### PR DESCRIPTION
## Summary
- add `dsl.simple_rules` with a helper rule
- expose `add_basic_rules` via the dsl package
- document DSL example in README
- adjust imports to avoid absolute package path
- test the new rule

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b80fa8d2c832c93aeee83b3eeaf8f